### PR TITLE
using SdBaseFile instead of SdFile, because it's smaller

### DIFF
--- a/MaxDuino_v1.76.ino
+++ b/MaxDuino_v1.76.ino
@@ -158,7 +158,7 @@
 char fline[17];
 
 SdFat sd;                           //Initialise Sd card 
-SdFile entry;                       //SD card file
+SdBaseFile entry;                       //SD card file
 
 #define subdirLength     22         // hasta 62 no incrementa el consumo de RAM
 #define filenameLength   4*subdirLength  //Maximum length for scrolling filename, hasta 255 no incrementa consumo RAM
@@ -2337,5 +2337,3 @@ switch(subdir){
 
 #endif
 }
-
-


### PR DESCRIPTION
SdBaseFile doesn't have Arduino Stream or Print support.  And we're not using those features.  And using SdBaseFile (instead of SdFile) reduces firmware size by about 1200 bytes on arduino nano, with (I think) no loss of functionality or performance.